### PR TITLE
[fix] generate image public url in image adapter

### DIFF
--- a/connector_prestashop/models/product_image/importer.py
+++ b/connector_prestashop/models/product_image/importer.py
@@ -46,14 +46,7 @@ class ProductImageMapper(ImportMapper):
 
     @mapping
     def image_url(self, record):
-        url = self.backend_record.location.encode()
-        url += '/img/p/' + '/'.join(list(record['id_image']))
-        extension = ''
-        if record['type'] == 'image/jpeg':
-            extension = '.jpg'
-        url += '/' + record['id_image'] + extension
-        return {'url': url}
-        # return {'storage': 'db'}
+        return {'url': record['full_public_url']}
 
     @mapping
     def filename(self, record):

--- a/connector_prestashop/unit/backend_adapter.py
+++ b/connector_prestashop/unit/backend_adapter.py
@@ -66,12 +66,23 @@ class PrestaShopWebServiceImage(PrestaShopWebServiceDict):
         else:
             image_content = ''
 
-        return {
+        record = {
             'type': response.headers['content-type'],
             'content': image_content,
             'id_' + resource[:-1]: resource_id,
-            'id_image': image_id
+            'id_image': image_id,
         }
+        record['full_public_url'] = self.get_image_public_url(record)
+        return record
+
+    def get_image_public_url(self, record):
+        url = self._api_url.replace('/api', '')
+        url += '/img/p/' + '/'.join(list(record['id_image']))
+        extension = ''
+        if record['type'] == 'image/jpeg':
+            extension = '.jpg'
+        url += '/' + record['id_image'] + extension
+        return url
 
 
 class PrestaShopLocation(object):


### PR DESCRIPTION
If api location is w/out "http://" the final url is wrong.
Also, is wrong to generate it in the mapper
instead of the specific adapter that already prepares image values.